### PR TITLE
Port to xdg-shell from xdg-shell-unstable-v6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PREFIX = /usr
 SYSCONFDIR = /etc
 BINDIR = $(PREFIX)/bin
 SRCFILES := sommelier.c version.h
-XMLFILES := aura-shell.xml viewporter.xml xdg-shell-unstable-v6.xml linux-dmabuf-unstable-v1.xml drm.xml keyboard-extension-unstable-v1.xml gtk-shell.xml
+XMLFILES := aura-shell.xml viewporter.xml xdg-shell.xml linux-dmabuf-unstable-v1.xml drm.xml keyboard-extension-unstable-v1.xml gtk-shell.xml
 AUXFILES := Makefile README LICENSE AUTHORS sommelier@.service.in sommelier-x@.service.in sommelierrc sommelier.sh
 ALLFILES := $(SRCFILES) $(XMLFILES) $(AUXFILES)
 GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
@@ -17,8 +17,8 @@ DIST_VERSION_MINOR := $(word 2,$(DIST_VERSION_BITS))
 DIST_VERSION_MINOR_NEXT := $(shell expr $(DIST_VERSION_MINOR) + 1)
 CFLAGS=-g -Wall `pkg-config --cflags xcb xcb-composite xcb-xfixes wayland-server wayland-client gbm pixman-1` -I. -D_GNU_SOURCE=1 -DWL_HIDE_DEPRECATED=1 -DXWAYLAND_PATH=\"$(PREFIX)/bin/Xwayland\"
 LDFLAGS=-lpthread -lm `pkg-config --libs xcb xcb-composite xcb-xfixes wayland-server wayland-client gbm pixman-1 xkbcommon`
-DEPS = xdg-shell-unstable-v6-client-protocol.h xdg-shell-unstable-v6-server-protocol.h aura-shell-client-protocol.h viewporter-client-protocol.h linux-dmabuf-unstable-v1-client-protocol.h drm-server-protocol.h keyboard-extension-unstable-v1-client-protocol.h gtk-shell-server-protocol.h
-OBJECTS = sommelier.o xdg-shell-unstable-v6-protocol.o aura-shell-protocol.o viewporter-protocol.o linux-dmabuf-unstable-v1-protocol.o drm-protocol.o keyboard-extension-unstable-v1-protocol.o gtk-shell-protocol.o
+DEPS = xdg-shell-client-protocol.h xdg-shell-server-protocol.h aura-shell-client-protocol.h viewporter-client-protocol.h linux-dmabuf-unstable-v1-client-protocol.h drm-server-protocol.h keyboard-extension-unstable-v1-client-protocol.h gtk-shell-server-protocol.h
+OBJECTS = sommelier.o xdg-shell-protocol.o aura-shell-protocol.o viewporter-protocol.o linux-dmabuf-unstable-v1-protocol.o drm-protocol.o keyboard-extension-unstable-v1-protocol.o gtk-shell-protocol.o
 
 all: sommelier sommelier@.service sommelier-x@.service
 

--- a/sommelier.gyp
+++ b/sommelier.gyp
@@ -14,7 +14,7 @@
         'keyboard-extension-unstable-v1.xml',
         'linux-dmabuf-unstable-v1.xml',
         'viewporter.xml',
-        'xdg-shell-unstable-v6.xml',
+        'xdg-shell.xml',
       ],
       'includes': ['wayland-protocol.gypi'],
     },

--- a/xdg-shell.xml
+++ b/xdg-shell.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<protocol name="xdg_shell_unstable_v6">
+<protocol name="xdg_shell">
 
   <copyright>
     Copyright © 2008-2013 Kristian Høgsberg
     Copyright © 2013      Rafael Antognolli
     Copyright © 2013      Jasper St. Pierre
     Copyright © 2010-2013 Intel Corporation
+    Copyright © 2015-2017 Samsung Electronics Co., Ltd
+    Copyright © 2015-2017 Red Hat Inc.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -27,18 +29,19 @@
     DEALINGS IN THE SOFTWARE.
   </copyright>
 
-  <interface name="zxdg_shell_v6" version="1">
+  <interface name="xdg_wm_base" version="2">
     <description summary="create desktop-style surfaces">
-      xdg_shell allows clients to turn a wl_surface into a "real window"
-      which can be dragged, resized, stacked, and moved around by the
-      user. Everything about this interface is suited towards traditional
-      desktop environments.
+      The xdg_wm_base interface is exposed as a global object enabling clients
+      to turn their wl_surfaces into windows in a desktop environment. It
+      defines the basic functionality needed for clients and the compositor to
+      create windows that can be dragged, resized, maximized, etc, as well as
+      creating transient windows such as popup menus.
     </description>
 
     <enum name="error">
       <entry name="role" value="0" summary="given wl_surface has another role"/>
       <entry name="defunct_surfaces" value="1"
-	     summary="xdg_shell was destroyed before children"/>
+	     summary="xdg_wm_base was destroyed before children"/>
       <entry name="not_the_topmost_popup" value="2"
 	     summary="the client tried to map or destroy a non-topmost popup"/>
       <entry name="invalid_popup_parent" value="3"
@@ -50,11 +53,11 @@
     </enum>
 
     <request name="destroy" type="destructor">
-      <description summary="destroy xdg_shell">
-	Destroy this xdg_shell object.
+      <description summary="destroy xdg_wm_base">
+	Destroy this xdg_wm_base object.
 
-	Destroying a bound xdg_shell object while there are surfaces
-	still alive created by this xdg_shell object instance is illegal
+	Destroying a bound xdg_wm_base object while there are surfaces
+	still alive created by this xdg_wm_base object instance is illegal
 	and will result in a protocol error.
       </description>
     </request>
@@ -65,7 +68,7 @@
 	surfaces relative to some parent surface. See the interface description
 	and xdg_surface.get_popup for details.
       </description>
-      <arg name="id" type="new_id" interface="zxdg_positioner_v6"/>
+      <arg name="id" type="new_id" interface="xdg_positioner"/>
     </request>
 
     <request name="get_xdg_surface">
@@ -82,14 +85,14 @@
 	See the documentation of xdg_surface for more details about what an
 	xdg_surface is and how it is used.
       </description>
-      <arg name="id" type="new_id" interface="zxdg_surface_v6"/>
+      <arg name="id" type="new_id" interface="xdg_surface"/>
       <arg name="surface" type="object" interface="wl_surface"/>
     </request>
 
     <request name="pong">
       <description summary="respond to a ping event">
 	A client must respond to a ping event with a pong request or
-	the client may be deemed unresponsive. See xdg_shell.ping.
+	the client may be deemed unresponsive. See xdg_wm_base.ping.
       </description>
       <arg name="serial" type="uint" summary="serial of the ping event"/>
     </request>
@@ -98,7 +101,7 @@
       <description summary="check if the client is alive">
 	The ping event asks the client if it's still alive. Pass the
 	serial specified in the event back to the compositor by sending
-	a "pong" request back with the specified serial. See xdg_shell.ping.
+	a "pong" request back with the specified serial. See xdg_wm_base.pong.
 
 	Compositors can use this to determine if the client is still
 	alive. It's unspecified what will happen if the client doesn't
@@ -106,13 +109,13 @@
 	try to respond in a reasonable amount of time.
 
 	A compositor is free to ping in any way it wants, but a client must
-	always respond to any xdg_shell object it created.
+	always respond to any xdg_wm_base object it created.
       </description>
       <arg name="serial" type="uint" summary="pass this to the pong request"/>
     </event>
   </interface>
 
-  <interface name="zxdg_positioner_v6" version="1">
+  <interface name="xdg_positioner" version="2">
     <description summary="child surface positioner">
       The xdg_positioner provides a collection of rules for the placement of a
       child surface relative to a parent surface. Rules can be defined to ensure
@@ -162,13 +165,13 @@
 	Specify the anchor rectangle within the parent surface that the child
 	surface will be placed relative to. The rectangle is relative to the
 	window geometry as defined by xdg_surface.set_window_geometry of the
-	parent surface. The rectangle must be at least 1x1 large.
+	parent surface.
 
 	When the xdg_positioner object is used to position a child surface, the
 	anchor rectangle may not extend outside the window geometry of the
 	positioned child's parent surface.
 
-	If a zero or negative size is set the invalid_input error is raised.
+	If a negative size is set the invalid_input error is raised.
       </description>
       <arg name="x" type="int" summary="x position of anchor rectangle"/>
       <arg name="y" type="int" summary="y position of anchor rectangle"/>
@@ -176,63 +179,54 @@
       <arg name="height" type="int" summary="height of anchor rectangle"/>
     </request>
 
-    <enum name="anchor" bitfield="true">
-      <entry name="none" value="0"
-	     summary="the center of the anchor rectangle"/>
-      <entry name="top" value="1"
-	     summary="the top edge of the anchor rectangle"/>
-      <entry name="bottom" value="2"
-	     summary="the bottom edge of the anchor rectangle"/>
-      <entry name="left" value="4"
-	     summary="the left edge of the anchor rectangle"/>
-      <entry name="right" value="8"
-	     summary="the right edge of the anchor rectangle"/>
+    <enum name="anchor">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
     </enum>
 
     <request name="set_anchor">
-      <description summary="set anchor rectangle anchor edges">
-	Defines a set of edges for the anchor rectangle. These are used to
-	derive an anchor point that the child surface will be positioned
-	relative to. If two orthogonal edges are specified (e.g. 'top' and
-	'left'), then the anchor point will be the intersection of the edges
-	(e.g. the top left position of the rectangle); otherwise, the derived
-	anchor point will be centered on the specified edge, or in the center of
-	the anchor rectangle if no edge is specified.
-
-	If two parallel anchor edges are specified (e.g. 'left' and 'right'),
-	the invalid_input error is raised.
+      <description summary="set anchor rectangle anchor">
+	Defines the anchor point for the anchor rectangle. The specified anchor
+	is used derive an anchor point that the child surface will be
+	positioned relative to. If a corner anchor is set (e.g. 'top_left' or
+	'bottom_right'), the anchor point will be at the specified corner;
+	otherwise, the derived anchor point will be centered on the specified
+	edge, or in the center of the anchor rectangle if no edge is specified.
       </description>
       <arg name="anchor" type="uint" enum="anchor"
-	   summary="bit mask of anchor edges"/>
+	   summary="anchor"/>
     </request>
 
-    <enum name="gravity" bitfield="true">
-      <entry name="none" value="0"
-	     summary="center over the anchor edge"/>
-      <entry name="top" value="1"
-	     summary="position above the anchor edge"/>
-      <entry name="bottom" value="2"
-	     summary="position below the anchor edge"/>
-      <entry name="left" value="4"
-	     summary="position to the left of the anchor edge"/>
-      <entry name="right" value="8"
-	     summary="position to the right of the anchor edge"/>
+    <enum name="gravity">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
     </enum>
 
     <request name="set_gravity">
       <description summary="set child surface gravity">
 	Defines in what direction a surface should be positioned, relative to
-	the anchor point of the parent surface. If two orthogonal gravities are
-	specified (e.g. 'bottom' and 'right'), then the child surface will be
-	placed in the specified direction; otherwise, the child surface will be
-	centered over the anchor point on any axis that had no gravity
-	specified.
-
-	If two parallel gravities are specified (e.g. 'left' and 'right'), the
-	invalid_input error is raised.
+	the anchor point of the parent surface. If a corner gravity is
+	specified (e.g. 'bottom_right' or 'top_left'), then the child surface
+	will be placed towards the specified gravity; otherwise, the child
+	surface will be centered over the anchor point on any axis that had no
+	gravity specified.
       </description>
       <arg name="gravity" type="uint" enum="gravity"
-	   summary="bit mask of gravity directions"/>
+	   summary="gravity direction"/>
     </request>
 
     <enum name="constraint_adjustment" bitfield="true">
@@ -252,7 +246,7 @@
       <entry name="none" value="0">
 	<description summary="don't move the child surface when constrained">
 	  Don't alter the surface position even if it is constrained on some
-	  axis, for example partially outside the edge of a monitor.
+	  axis, for example partially outside the edge of an output.
 	</description>
       </entry>
       <entry name="slide_x" value="1">
@@ -303,6 +297,10 @@
 	  constrained on the y axis. For example, if the bottom edge of the
 	  surface is constrained, the gravity is 'bottom' and the anchor is
 	  'bottom', change the gravity to 'top' and the anchor to 'top'.
+
+	  The adjusted position is calculated given the original anchor
+	  rectangle and offset, but with the new flipped anchor and gravity
+	  values.
 
 	  If the adjusted position also ends up being constrained, the resulting
 	  position of the flip_y adjustment will be the one before the
@@ -361,7 +359,7 @@
     </request>
   </interface>
 
-  <interface name="zxdg_surface_v6" version="1">
+  <interface name="xdg_surface" version="2">
     <description summary="desktop user interface surface base interface">
       An interface that may be implemented by a wl_surface, for
       implementations that provide a desktop-style user interface.
@@ -388,11 +386,20 @@
       manipulate a buffer prior to the first xdg_surface.configure call must
       also be treated as errors.
 
-      For a surface to be mapped by the compositor, the following conditions
-      must be met: (1) the client has assigned a xdg_surface based role to the
-      surface, (2) the client has set and committed the xdg_surface state and
-      the role dependent state to the surface and (3) the client has committed a
-      buffer to the surface.
+      Mapping an xdg_surface-based role surface is defined as making it
+      possible for the surface to be shown by the compositor. Note that
+      a mapped surface is not guaranteed to be visible once it is mapped.
+
+      For an xdg_surface to be mapped by the compositor, the following
+      conditions must be met:
+      (1) the client has assigned an xdg_surface-based role to the surface
+      (2) the client has set and committed the xdg_surface state and the
+	  role-dependent state to the surface
+      (3) the client has committed a buffer to the surface
+
+      A newly-unmapped surface is considered to have met condition (1) out
+      of the 3 required conditions for mapping a surface if its role surface
+      has not been destroyed.
     </description>
 
     <enum name="error">
@@ -416,20 +423,23 @@
 	See the documentation of xdg_toplevel for more details about what an
 	xdg_toplevel is and how it is used.
       </description>
-      <arg name="id" type="new_id" interface="zxdg_toplevel_v6"/>
+      <arg name="id" type="new_id" interface="xdg_toplevel"/>
     </request>
 
     <request name="get_popup">
       <description summary="assign the xdg_popup surface role">
-	This creates an xdg_popup object for the given xdg_surface and gives the
-	associated wl_surface the xdg_popup role.
+	This creates an xdg_popup object for the given xdg_surface and gives
+	the associated wl_surface the xdg_popup role.
+
+	If null is passed as a parent, a parent surface must be specified using
+	some other protocol, before committing the initial state.
 
 	See the documentation of xdg_popup for more details about what an
 	xdg_popup is and how it is used.
       </description>
-      <arg name="id" type="new_id" interface="zxdg_popup_v6"/>
-      <arg name="parent" type="object" interface="zxdg_surface_v6"/>
-      <arg name="positioner" type="object" interface="zxdg_positioner_v6"/>
+      <arg name="id" type="new_id" interface="xdg_popup"/>
+      <arg name="parent" type="object" interface="xdg_surface" allow-null="true"/>
+      <arg name="positioner" type="object" interface="xdg_positioner"/>
     </request>
 
     <request name="set_window_geometry">
@@ -441,6 +451,11 @@
 
 	The window geometry is double buffered, and will be applied at the
 	time wl_surface.commit of the corresponding wl_surface is called.
+
+	When maintaining a position, the compositor should treat the (x, y)
+	coordinate of the window geometry as the top left corner of the window.
+	A client changing the (x, y) window geometry coordinate should in
+	general not alter the position of the window.
 
 	Once the window geometry of the surface is set, it is not possible to
 	unset it, and it will remain the same until set_window_geometry is
@@ -513,34 +528,50 @@
     </event>
   </interface>
 
-  <interface name="zxdg_toplevel_v6" version="1">
+  <interface name="xdg_toplevel" version="2">
     <description summary="toplevel surface">
       This interface defines an xdg_surface role which allows a surface to,
       among other things, set window-like properties such as maximize,
       fullscreen, and minimize, set application-specific metadata like title and
       id, and well as trigger user interactive operations such as interactive
       resize and move.
+
+      Unmapping an xdg_toplevel means that the surface cannot be shown
+      by the compositor until it is explicitly mapped again.
+      All active operations (e.g., move, resize) are canceled and all
+      attributes (e.g. title, state, stacking, ...) are discarded for
+      an xdg_toplevel surface when it is unmapped.
+
+      Attaching a null buffer to a toplevel unmaps the surface.
     </description>
 
     <request name="destroy" type="destructor">
       <description summary="destroy the xdg_toplevel">
-	Unmap and destroy the window. The window will be effectively
-	hidden from the user's point of view, and all state like
-	maximization, fullscreen, and so on, will be lost.
+	This request destroys the role surface and unmaps the surface;
+	see "Unmapping" behavior in interface section for details.
       </description>
     </request>
 
     <request name="set_parent">
       <description summary="set the parent of this surface">
-	Set the "parent" of this surface. This window should be stacked
-	above a parent. The parent surface must be mapped as long as this
-	surface is mapped.
+	Set the "parent" of this surface. This surface should be stacked
+	above the parent surface and all other ancestor surfaces.
 
 	Parent windows should be set on dialogs, toolboxes, or other
 	"auxiliary" surfaces, so that the parent is raised when the dialog
 	is raised.
+
+	Setting a null parent for a child window removes any parent-child
+	relationship for the child. Setting a null parent for a window which
+	currently has no parent is a no-op.
+
+	If the parent is unmapped then its children are managed as
+	though the parent of the now-unmapped parent has become the
+	parent of this surface. If no parent exists for the now-unmapped
+	parent then the children are managed as though they have no
+	parent surface.
       </description>
-      <arg name="parent" type="object" interface="zxdg_toplevel_v6" allow-null="true"/>
+      <arg name="parent" type="object" interface="xdg_toplevel" allow-null="true"/>
     </request>
 
     <request name="set_title">
@@ -693,12 +724,18 @@
 	<description summary="the surface is maximized">
 	  The surface is maximized. The window geometry specified in the configure
 	  event must be obeyed by the client.
+
+	  The client should draw without shadow or other
+	  decoration outside of the window geometry.
 	</description>
       </entry>
       <entry name="fullscreen" value="2" summary="the surface is fullscreen">
 	<description summary="the surface is fullscreen">
-	  The surface is fullscreen. The window geometry specified in the configure
-	  event must be obeyed by the client.
+	  The surface is fullscreen. The window geometry specified in the
+	  configure event is a maximum; the client cannot resize beyond it. For
+	  a surface to cover the whole fullscreened area, the geometry
+	  dimensions must be obeyed by the client. For more details, see
+	  xdg_toplevel.set_fullscreen.
 	</description>
       </entry>
       <entry name="resizing" value="3" summary="the surface is being resized">
@@ -714,6 +751,30 @@
 	  Client window decorations should be painted as if the window is
 	  active. Do not assume this means that the window actually has
 	  keyboard or pointer focus.
+	</description>
+      </entry>
+      <entry name="tiled_left" value="5" since="2">
+	<description summary="the surface is tiled">
+	  The window is currently in a tiled layout and the left edge is
+	  considered to be adjacent to another part of the tiling grid.
+	</description>
+      </entry>
+      <entry name="tiled_right" value="6" since="2">
+	<description summary="the surface is tiled">
+	  The window is currently in a tiled layout and the right edge is
+	  considered to be adjacent to another part of the tiling grid.
+	</description>
+      </entry>
+      <entry name="tiled_top" value="7" since="2">
+	<description summary="the surface is tiled">
+	  The window is currently in a tiled layout and the top edge is
+	  considered to be adjacent to another part of the tiling grid.
+	</description>
+      </entry>
+      <entry name="tiled_bottom" value="8" since="2">
+	<description summary="the surface is tiled">
+	  The window is currently in a tiled layout and the bottom edge is
+	  considered to be adjacent to another part of the tiling grid.
 	</description>
       </entry>
     </enum>
@@ -805,12 +866,11 @@
 	Maximize the surface.
 
 	After requesting that the surface should be maximized, the compositor
-	will respond by emitting a configure event with the "maximized" state
-	and the required window geometry. The client should then update its
-	content, drawing it in a maximized state, i.e. without shadow or other
-	decoration outside of the window geometry. The client must also
-	acknowledge the configure when committing the new content (see
-	ack_configure).
+	will respond by emitting a configure event. Whether this configure
+	actually sets the window maximized is subject to compositor policies.
+	The client must then update its content, drawing in the configured
+	state. The client must also acknowledge the configure when committing
+	the new content (see ack_configure).
 
 	It is up to the compositor to decide how and where to maximize the
 	surface, for example which output and what region of the screen should
@@ -818,6 +878,10 @@
 
 	If the surface was already maximized, the compositor will still emit
 	a configure event with the "maximized" state.
+
+	If the surface is in a fullscreen state, this request has no direct
+	effect. It may alter the state the surface is returned to when
+	unmaximized unless overridden by the compositor.
       </description>
     </request>
 
@@ -826,13 +890,13 @@
 	Unmaximize the surface.
 
 	After requesting that the surface should be unmaximized, the compositor
-	will respond by emitting a configure event without the "maximized"
-	state. If available, the compositor will include the window geometry
-	dimensions the window had prior to being maximized in the configure
-	request. The client must then update its content, drawing it in a
-	regular state, i.e. potentially with shadow, etc. The client must also
-	acknowledge the configure when committing the new content (see
-	ack_configure).
+	will respond by emitting a configure event. Whether this actually
+	un-maximizes the window is subject to compositor policies.
+	If available and applicable, the compositor will include the window
+	geometry dimensions the window had prior to being maximized in the
+	configure event. The client must then update its content, drawing it in
+	the configured state. The client must also acknowledge the configure
+	when committing the new content (see ack_configure).
 
 	It is up to the compositor to position the surface after it was
 	unmaximized; usually the position the surface had before maximizing, if
@@ -840,24 +904,63 @@
 
 	If the surface was already not maximized, the compositor will still
 	emit a configure event without the "maximized" state.
+
+	If the surface is in a fullscreen state, this request has no direct
+	effect. It may alter the state the surface is returned to when
+	unmaximized unless overridden by the compositor.
       </description>
     </request>
 
     <request name="set_fullscreen">
-      <description summary="set the window as fullscreen on a monitor">
+      <description summary="set the window as fullscreen on an output">
 	Make the surface fullscreen.
 
-	You can specify an output that you would prefer to be fullscreen.
-	If this value is NULL, it's up to the compositor to choose which
-	display will be used to map this surface.
+	After requesting that the surface should be fullscreened, the
+	compositor will respond by emitting a configure event. Whether the
+	client is actually put into a fullscreen state is subject to compositor
+	policies. The client must also acknowledge the configure when
+	committing the new content (see ack_configure).
+
+	The output passed by the request indicates the client's preference as
+	to which display it should be set fullscreen on. If this value is NULL,
+	it's up to the compositor to choose which display will be used to map
+	this surface.
 
 	If the surface doesn't cover the whole output, the compositor will
 	position the surface in the center of the output and compensate with
-	black borders filling the rest of the output.
+	with border fill covering the rest of the output. The content of the
+	border fill is undefined, but should be assumed to be in some way that
+	attempts to blend into the surrounding area (e.g. solid black).
+
+	If the fullscreened surface is not opaque, the compositor must make
+	sure that other screen content not part of the same surface tree (made
+	up of subsurfaces, popups or similarly coupled surfaces) are not
+	visible below the fullscreened surface.
       </description>
       <arg name="output" type="object" interface="wl_output" allow-null="true"/>
     </request>
-    <request name="unset_fullscreen" />
+
+    <request name="unset_fullscreen">
+      <description summary="unset the window as fullscreen">
+	Make the surface no longer fullscreen.
+
+	After requesting that the surface should be unfullscreened, the
+	compositor will respond by emitting a configure event.
+	Whether this actually removes the fullscreen state of the client is
+	subject to compositor policies.
+
+	Making a surface unfullscreen sets states for the surface based on the following:
+	* the state(s) it may have had before becoming fullscreen
+	* any state(s) decided by the compositor
+	* any state(s) requested by the client while the surface was fullscreen
+
+	The compositor may include the previous window geometry dimensions in
+	the configure event, if applicable.
+
+	The client must also acknowledge the configure when committing the new
+	content (see ack_configure).
+      </description>
+    </request>
 
     <request name="set_minimized">
       <description summary="set the window as minimized">
@@ -913,7 +1016,7 @@
     </event>
   </interface>
 
-  <interface name="zxdg_popup_v6" version="1">
+  <interface name="xdg_popup" version="2">
     <description summary="short-lived, popup surfaces for menus">
       A popup surface is a short-lived, temporary surface. It can be used to
       implement for example menus, popovers, tooltips and other similar user
@@ -930,9 +1033,6 @@
       unmap the surface. Clients that want to dismiss the popup when another
       surface of their own is clicked should dismiss the popup using the destroy
       request.
-
-      The parent surface must have either the xdg_toplevel or xdg_popup surface
-      role.
 
       A newly created xdg_popup will be stacked on top of all previously created
       xdg_popup surfaces associated with the same xdg_toplevel.


### PR DESCRIPTION
Solves the `zxdg_popup_v6` issues for me, at least when running pluma. May or may not help, but it's anyway good to move to a stable protocol. Haven't really tested the changes.